### PR TITLE
Lattice file parser raises exception on error. Code clean up

### DIFF
--- a/thor/inc/prtmfile.h
+++ b/thor/inc/prtmfile.h
@@ -11,6 +11,11 @@
 #ifndef PRTMFILE_H
 #define PRTMFILE_H
 
-void prtmfile(const char mfile_dat[]);
+/* does not exist any more
+ *
+ * use LatticeType::prtmfile instead
+
+ * *  void prtmfile(const char mfile_dat[]);
+ */
 
 #endif

--- a/thor/src/exceptions.cc
+++ b/thor/src/exceptions.cc
@@ -1,0 +1,29 @@
+#include <exception>
+
+class InvalidPosition: public std::exception
+{
+  virtual const char* what() const throw()
+  {
+    return "Invalid position";
+  }
+};
+
+/**  Last position eg. 0 or 1
+ *   Most probably none reached
+ */
+class InvalidLastPosition: public InvalidPosition
+{
+  virtual const char* what() const throw()
+  {
+    return "Invalid last position";
+  }
+}invalid_last_position;
+
+class LatticeParseError: public std::exception
+{
+  virtual const char* what() const throw()
+  {
+    return "Lattice parse error";
+  }
+
+}lattice_parse_error;

--- a/thor/src/t2lat.cc
+++ b/thor/src/t2lat.cc
@@ -4141,7 +4141,7 @@ void PrintResult(struct LOC_Lat_Read *LINK)
 }
 
 
-bool LatticeType::Lat_Read(const std::string &filnam)
+void LatticeType::Lat_Read(const std::string &filename, bool verbose)
 {
   struct LOC_Lat_Read V;
   FILE                *fi_, *fo_;
@@ -4151,8 +4151,8 @@ bool LatticeType::Lat_Read(const std::string &filnam)
   ElemFam_ = &elemf;
   Lat_     = this;
 
-  fi_ = file_read((filnam+".lat").c_str());
-  fo_ = file_write((filnam+".lax").c_str());
+  fi_ = file_read((filename+".lat").c_str());
+  fo_ = file_write((filename+".lax").c_str());
 
   if (Lat_->conf.trace)
     printf("\nLat_Read: dndsym = %d, solsym = %d, max_set = %d"
@@ -4194,12 +4194,21 @@ bool LatticeType::Lat_Read(const std::string &filnam)
   RegisterKids(&V);                 /* Check wether too many elements */
 
   if (debug) this->prt_fams();
-  PrintResult(&V);                  /* Print lattice statistics */
+  if(verbose){
+    PrintResult(&V);                  /* Print lattice statistics */
+  }
 
   delete V.line;
 
  _L9999:
-  return (!Lat_->conf.ErrFlag);
+
+  // return (!Lat_->conf.ErrFlag);
+  if(Lat_->conf.ErrFlag){
+    /* parse error occurred */
+    std::cerr << __FILE__ << "@" << __LINE__
+	      << " failed to parse lattice: >" << filename <<"<" << std::endl;
+    throw lattice_parse_error;
+  }
 }
 
 #undef UDImax

--- a/thor/src/thor_lib.cc
+++ b/thor/src/thor_lib.cc
@@ -10,6 +10,7 @@
 
 #include "thor_lib.h"
 
+#include "exceptions.cc"
 #include "field.cc"
 
 #if NO_TPSA == 1


### PR DESCRIPTION
prtmfile.h: Not existing function commented out. Documented
            replacement

exceptions.cc: defined exceptions (to be moved to header)
t2lat.cc: exception raised if lattice can not be parsed
          offending file printed to cerr stream
thor_lib.cc :: including exceptions