### PR TITLE
elements filters using std:ranges if compiler support it: experimental

### DIFF
--- a/thor/inc/thor_scsi/core/cpp_ranges.h
+++ b/thor/inc/thor_scsi/core/cpp_ranges.h
@@ -1,0 +1,26 @@
+#ifndef _THOR_SCSI_CPP_RANGES_VERSION_H_
+#define _THOR_SCSI_CPP_RANGES_VERSION_H_ 1
+
+/**
+ * Use std::ranges if compiler has support for it
+ * Otherwise use range/v3 see e.g. https://github.com/ericniebler/range-v3
+ *
+ */
+#include <thor_scsi/core/cpp_version.h>
+#include <version>
+
+#ifdef __cpp_lib_ranges
+#warning "using std::ranges"
+#include <ranges>
+// namespace ranges=std::ranges;
+#else
+#warning "using range-v3"
+#error "using range-v3"
+#include <vector>
+#include <set>
+#include <unordered_set>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/transform.hpp>
+#endif
+
+#endif /*  _THOR_SCSI_CPP_RANGES_VERSION_H_ */

--- a/thor/inc/thor_scsi/core/cpp_version.h
+++ b/thor/inc/thor_scsi/core/cpp_version.h
@@ -1,6 +1,7 @@
 #ifndef _THOR_SCSI_CPP_VERSION_H_
 #define _THOR_SCSI_CPP_VERSION_H_ 1
 
+#include <version>
 #if __cplusplus < 201100
 #  error "C++11 or better is required"
 #endif

--- a/thor/inc/thor_scsi/core/elements_filter.h
+++ b/thor/inc/thor_scsi/core/elements_filter.h
@@ -3,25 +3,10 @@
 
 /**
  * Todo:
- *    automatically include std::ranges if available
+ *    automatically include std::ranges if available ... currently work in progress
  */
-// #include <algorithm>
-// #ifdef __cpp_lib_ranges
-// #error "ranges"
-// #include <ranges>
-// #else
-// #error "No ranges"
-// #endif
-
-#include <thor_scsi/core/cpp_version.h>
-
-#include <vector>
-#include <set>
-#include <unordered_set>
 #include <cassert>
-#include <range/v3/view/filter.hpp>
-#include <range/v3/view/transform.hpp>
-
+#include <thor_scsi/core/cpp_ranges.h>
 #include <thor_scsi/core/elements.h>
 
 /*


### PR DESCRIPTION
lattice elements can be filtered by type: functionality provided in
elements_filter.h based on ranges.

Now using std::ranges if compiler supports it. using range-v3 otherwise